### PR TITLE
Potential fix for code scanning alert no. 1: Incomplete URL substring sanitization

### DIFF
--- a/common/file_utils.py
+++ b/common/file_utils.py
@@ -112,7 +112,10 @@ def get_file(fname, origin, untar=False,
     '''
 
     if download:
-        if 'modac.cancer.gov' in origin:
+        from urllib.parse import urlparse
+        parsed_url = urlparse(origin)
+        host = parsed_url.hostname
+        if host == "modac.cancer.gov" or (host and host.endswith(".modac.cancer.gov")):
             get_file_from_modac(fpath, origin)
         else:
             print('Downloading data from', origin)

--- a/common/file_utils.py
+++ b/common/file_utils.py
@@ -115,7 +115,7 @@ def get_file(fname, origin, untar=False,
         from urllib.parse import urlparse
         parsed_url = urlparse(origin)
         host = parsed_url.hostname
-        if host == "modac.cancer.gov" or (host and host.endswith(".modac.cancer.gov")):
+        if host and host.endswith(".modac.cancer.gov"):
             get_file_from_modac(fpath, origin)
         else:
             print('Downloading data from', origin)


### PR DESCRIPTION
Potential fix for [https://github.com/CBIIT/NCI-DOE-Collab-Pilot1-Tumor-Classifier/security/code-scanning/1](https://github.com/CBIIT/NCI-DOE-Collab-Pilot1-Tumor-Classifier/security/code-scanning/1)

To fix the issue, we need to replace the substring check `'modac.cancer.gov' in origin` with a more secure method that parses the URL and validates the hostname. The `urllib.parse` module can be used to extract the hostname from the URL, and we can then check if it matches the intended domain (`modac.cancer.gov`). This ensures that only URLs with the exact hostname or valid subdomains are accepted.

Steps to implement the fix:
1. Import the `urlparse` function from `urllib.parse`.
2. Parse the `origin` URL to extract its hostname.
3. Check if the hostname matches `modac.cancer.gov` or ends with `.modac.cancer.gov` (to allow subdomains if needed).

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
